### PR TITLE
improving the status command behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,27 @@ files describing the registries reside.
 $ registryman status <path-to-configuration-dir>
 ```
 
+It's possible to check the status of the registries that are stored as
+Kubernetes Registry resources.
+
+```bash
+$ registryman status
+```
+
+By default, all configured registried are checked. You can filter for registries
+using the `-r` flag.
+
+```bash
+$ registryman status -r harbor-1,harbor-2
+```
+
+The default output format is JSON. It's possible to output the result as YAML
+too.
+
+```bash
+$ registryman status -r harbor-1 -o yaml
+```
+
 ### Validating the config files
 
 Registryman can validate the configuration files using the `validate` command.

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -21,11 +21,32 @@ import (
 	"fmt"
 	"os"
 
+	api "github.com/kubermatic-labs/registryman/pkg/apis/registryman/v1alpha1"
 	"github.com/kubermatic-labs/registryman/pkg/config"
 	"github.com/kubermatic-labs/registryman/pkg/globalregistry/reconciler"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
 	"k8s.io/client-go/rest"
 )
+
+var filteredRegistries []string
+var outputEncoder string
+
+func registryInScope(registryName string) bool {
+	if len(filteredRegistries) == 0 {
+		return true
+	}
+	for _, filteredRegistry := range filteredRegistries {
+		if registryName == filteredRegistry {
+			return true
+		}
+	}
+	return false
+}
+
+type encoder interface {
+	Encode(v interface{}) (err error)
+}
 
 // statusCmd represents the status command
 var statusCmd = &cobra.Command{
@@ -54,32 +75,41 @@ var statusCmd = &cobra.Command{
 		}
 
 		expectedRegistries := config.NewExpectedProvider(aos).GetRegistries()
+		registryStatuses := map[string]*api.RegistryStatus{}
 		for _, expectedRegistry := range expectedRegistries {
-			fmt.Println("#")
-			fmt.Println("#")
-			fmt.Printf("# %s\n", expectedRegistry.GetName())
-			fmt.Println("#")
-			fmt.Println("#")
+			if !registryInScope(expectedRegistry.GetName()) {
+				continue
+			}
 			actualRegistry, err := expectedRegistry.ToReal()
 			if err != nil {
 				return err
 			}
-			regStatusActual, err := reconciler.GetRegistryStatus(actualRegistry)
-			if err != nil {
-				return err
-			}
-			encoder := json.NewEncoder(os.Stdout)
-			encoder.SetIndent("", "  ")
-			err = encoder.Encode(regStatusActual)
+			registryStatuses[expectedRegistry.GetName()], err = reconciler.GetRegistryStatus(actualRegistry)
 			if err != nil {
 				return err
 			}
 		}
+		var enc encoder
+		switch outputEncoder {
+		case "json":
+			enc = json.NewEncoder(os.Stdout)
+			enc.(*json.Encoder).SetIndent("", "  ")
+		case "yaml":
+			enc = yaml.NewEncoder(os.Stdout)
+		default:
+			return fmt.Errorf("invalid output format: %s", outputEncoder)
+		}
+		err = enc.Encode(registryStatuses)
 
-		return nil
+		return err
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(statusCmd)
+	statusCmd.PersistentFlags().StringSliceVarP(&filteredRegistries,
+		"registries",
+		"r",
+		[]string{}, "Select which registries shall be checked. When not set all registries will be checked.")
+	statusCmd.PersistentFlags().StringVarP(&outputEncoder, "output", "o", "json", "Output format. Supported values are json or yaml.")
 }

--- a/cmd/status_test.go
+++ b/cmd/status_test.go
@@ -1,0 +1,26 @@
+package cmd
+
+import "testing"
+
+func TestRegistryInScope(t *testing.T) {
+	filteredRegistries = []string{}
+	if !registryInScope("") {
+		t.Errorf("registryInScope shall return true when filteredRegistries is empty")
+	}
+	if !registryInScope("test") {
+		t.Errorf("registryInScope shall return true when filteredRegistries is empty")
+	}
+	filteredRegistries = []string{"reg1", "reg2", "reg3"}
+	if !registryInScope("reg1") {
+		t.Errorf("registryInScope shall return true for reg1")
+	}
+	if !registryInScope("reg2") {
+		t.Errorf("registryInScope shall return true for reg2")
+	}
+	if !registryInScope("reg3") {
+		t.Errorf("registryInScope shall return true for reg3")
+	}
+	if registryInScope("reg4") {
+		t.Errorf("registryInScope shall return false for reg4")
+	}
+}

--- a/pkg/config/kube_aos.go
+++ b/pkg/config/kube_aos.go
@@ -168,8 +168,8 @@ func (aos *kubeApiObjectStore) GetRegistries() []*api.Registry {
 		panic(err)
 	}
 	apiRegistries := make([]*api.Registry, len(registryList.Items))
-	for i, reg := range registryList.Items {
-		apiRegistries[i] = &reg
+	for i := range registryList.Items {
+		apiRegistries[i] = &registryList.Items[i]
 	}
 	return apiRegistries
 }
@@ -185,8 +185,8 @@ func (aos *kubeApiObjectStore) GetProjects() []*api.Project {
 		panic(err)
 	}
 	apiProjects := make([]*api.Project, len(projectList.Items))
-	for i, reg := range projectList.Items {
-		apiProjects[i] = &reg
+	for i := range projectList.Items {
+		apiProjects[i] = &projectList.Items[i]
 	}
 	return apiProjects
 }
@@ -202,8 +202,8 @@ func (aos *kubeApiObjectStore) GetScanners() []*api.Scanner {
 		panic(err)
 	}
 	apiScanners := make([]*api.Scanner, len(scannerList.Items))
-	for i, reg := range scannerList.Items {
-		apiScanners[i] = &reg
+	for i := range scannerList.Items {
+		apiScanners[i] = &scannerList.Items[i]
 	}
 	return apiScanners
 }


### PR DESCRIPTION
The `status` command of the registryman-cli has been improved:

- registryman CLI lets the users filter for a specific registry (-ies)
- the output supports JSON format
- the output supports YAML format